### PR TITLE
Always get store2

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,7 +119,7 @@ app.get('/fetch', cacheSuccesses, async(req, res, next) => {
       feeds = datasets.flatMap(dataset => (
         (dataset?.distribution ?? []).map(feedInfo => ({
           name: dataset.name,
-          kind: feedInfo.name,
+          type: feedInfo.name,
           url: feedInfo.contentUrl,
           datasetUrl: dataset.url,
           discussionUrl: dataset.discussionUrl,


### PR DESCRIPTION
- Changed back-end feed "kind" to "type" for front-end consistency
- Changed front-end store "type" to "ingressOrder" to avoid clashes with "type"
- Added an Object to store back-end feed info in the front-end for convenience
- Added feed type to the store, in addition to the existing item data type. In theory they should match, so running a check on that too.
- Allowed for "type" and "@type" key variants in the feed items
- Allowed for "IndividualFacilityUse" feeds, in addition to the existing "FacilityUse" feeds