### PR TITLE
Handle more sub-event feed types

### DIFF
--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -21,7 +21,7 @@ let keywords;
 let feeds = {};
 
 let superEventFeedTypes = ['SessionSeries', 'FacilityUse', 'IndividualFacilityUse'];
-let subEventFeedTypes = ['ScheduledSession', 'Slot'];
+let subEventFeedTypes = ['ScheduledSession', 'Slot', 'Event', 'OnDemandEvent'];
 
 let storeSuperEvent = {};
 let storeSubEvent = {};
@@ -261,8 +261,13 @@ function setStoreItems(url, store, filters) {
       console.log(`Finished loading storeIngressOrder${store.ingressOrder}`);
 
       if (store.ingressOrder === 1) {
-        console.log(`Started loading storeIngressOrder2`);
-        setStoreItems(storeIngressOrder2.firstPage, storeIngressOrder2, filters);
+        if (storeIngressOrder2.firstPage) {
+          console.log(`Started loading storeIngressOrder2`);
+          setStoreItems(storeIngressOrder2.firstPage, storeIngressOrder2, filters);
+        }
+        else {
+          loadingComplete();
+        }
       }
       else if (store.ingressOrder === 2) {
         loadingComplete();
@@ -996,6 +1001,16 @@ function runForm(pageNumber) {
       storeIngressOrder2.feedType = feeds[storeIngressOrder2.firstPage].type;
     }
 
+    console.log(`storeIngressOrder1 endpoint: ${storeIngressOrder1.firstPage}`);
+    console.log(`storeIngressOrder2 endpoint: ${storeIngressOrder2.firstPage}`);
+
+    if (!storeIngressOrder1.firstPage) {
+      console.warn('No storeIngressOrder1 endpoint, can\'t begin');
+    }
+    if (!storeIngressOrder2.firstPage) {
+      console.warn('No storeIngressOrder2 endpoint, can\'t create combined store');
+    }
+
     if (storeSubEvent.feedType === 'ScheduledSession') {
       link = 'superEvent';
     }
@@ -1006,11 +1021,10 @@ function runForm(pageNumber) {
       console.warn('No feed linking variable, can\'t create combined store');
     }
 
-    console.log(`storeIngressOrder1 endpoint: ${storeIngressOrder1.firstPage}`);
-    console.log(`storeIngressOrder2 endpoint: ${storeIngressOrder2.firstPage}`);
-
-    console.log(`Started loading storeIngressOrder1`);
-    setStoreItems(storeIngressOrder1.firstPage, storeIngressOrder1, filters);
+    if (storeIngressOrder1.firstPage) {
+      console.log(`Started loading storeIngressOrder1`);
+      setStoreItems(storeIngressOrder1.firstPage, storeIngressOrder1, filters);
+    }
   }
 }
 
@@ -1095,6 +1109,8 @@ function setPage() {
 
 function setEndpoints() {
   $.getJSON("/feeds", function (data) {
+    // Show all unique feed types:
+    // console.log([... new Set(data.feeds.map(feed => feed.type))]);
     $("#endpoint").empty();
     $.each(data.feeds, function (index, feed) {
       feeds[feed.url] = feed;

--- a/public/dq.js
+++ b/public/dq.js
@@ -44,8 +44,11 @@ function runDataQuality() {
       if (storeSubEventItem.data && storeSubEventItem.data[link] && typeof storeSubEventItem.data[link] === 'string') {
         const lastSlashIndex = storeSubEventItem.data[link].lastIndexOf('/');
         const storeSuperEventItemId = storeSubEventItem.data[link].substring(lastSlashIndex + 1);
-        const storeSuperEventItem = Object.values(storeSuperEvent.items).find(storeSuperEventItem => storeSuperEventItem.id === storeSuperEventItemId);
-        // If the match isn't found then the super-event has been deleted, so lose the sub-event info
+        // Note that we intentionally use '==' here and not '===' to cater for those storeSuperEventItem.id
+        // which are purely numeric and stored as a number rather than a string, so we can still match on
+        // storeSuperEventItemId which is always a string:
+        const storeSuperEventItem = Object.values(storeSuperEvent.items).find(storeSuperEventItem => storeSuperEventItem.id == storeSuperEventItemId);
+        // If the match isn't found then the super-event has been deleted, so lose the sub-event info:
         if (storeSuperEventItem && storeSuperEventItem.data) {
           // TODO: Double check if this deepcopy attempt correcty preserves type:
           let storeSubEventItemCopy = JSON.parse(JSON.stringify(storeSubEventItem));
@@ -308,10 +311,10 @@ function postDataQuality(items) {
 
   let spark1SeriesName = '';
   if (storeSuperEvent.feedType !== null) {
-    if (storeSuperEvent.feedType === 'SessionSeries') {
+    if (['SessionSeries'].includes(storeSuperEvent.feedType)) {
       spark1SeriesName = 'Series';
     }
-    else {
+    else if (['FacilityUse', 'IndividualFacilityUse'].includes(storeSuperEvent.feedType)) {
       spark1SeriesName = 'Facility Use';
       if (numListings !== 1) {
         spark1SeriesName += 's';
@@ -662,17 +665,17 @@ function postDataQuality(items) {
 
   let spark6SeriesName = '';
   if (storeSubEvent.feedType !== null) {
-    if (storeSubEvent.feedType === 'ScheduledSession') {
+    if (['ScheduledSession'].includes(storeSubEvent.feedType)) {
       spark6SeriesName = 'Session';
-      if (numOpps !== 1) {
-        spark6SeriesName += 's';
-      }
     }
-    else {
+    else if (['Slot'].includes(storeSubEvent.feedType)) {
       spark6SeriesName = 'Slot';
-      if (numOpps !== 1) {
-        spark6SeriesName += 's';
-      }
+    }
+    else if (['Event', 'OnDemandEvent'].includes(storeSubEvent.feedType)) {
+      spark6SeriesName = 'Event';
+    }
+    if (spark6SeriesName.length > 0 && numOpps !== 1) {
+      spark6SeriesName += 's';
     }
   }
 


### PR DESCRIPTION
- Normalised some feed types in app.js i.e. as early as possible in the process
- Catered for 'Event' and 'OnDemandEvent' sub-event feed types
- Handled non-existent storeIngressOrder1.firstPage and storeIngressOrder2.firstPage