### PR TITLE
Filters affect results and DQ charts

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,6 +116,27 @@ app.get('/fetch', cacheSuccesses, async(req, res, next) => {
       })))
       .filter(dataset => dataset);
 
+
+      //console.log(datasets);
+
+      console.log("Unique Types in feeds (untreated):");
+      const typeCounts = {};
+      
+      datasets.forEach(dataset => {
+        (dataset?.distribution ?? []).forEach(feedInfo => {
+          const { name } = feedInfo;
+          typeCounts[name] = (typeCounts[name] || 0) + 1;
+        });
+      });
+      
+      const sortedTypes = Object.keys(typeCounts).sort((a, b) => typeCounts[b] - typeCounts[a]);
+      
+      sortedTypes.forEach(type => {
+        console.log(`${type} (${typeCounts[type]})`);
+      });
+      
+      
+
 // Dataset providers should be encouraged to adjust the following in their dataset pages, and make
 // sure there are none which are undefined, then we won't need the normalisation in the following
 // code block:
@@ -136,6 +157,9 @@ app.get('/fetch', cacheSuccesses, async(req, res, next) => {
         })
       )))
       .filter(feed => feed.type !== 'CourseInstance')
+      .filter(feed => feed.type !== 'Event')
+      .filter(feed => feed.type !== undefined)
+      .filter(feed => feed.type !== 'OnDemandEvent')
       .filter(feed => feed.url && feed.name.substr(0,1).trim())
       .sort(function(feed1, feed2) {
          return feed1.name.toLowerCase().localeCompare(feed2.name.toLowerCase());
@@ -150,7 +174,9 @@ app.get('/fetch', cacheSuccesses, async(req, res, next) => {
         return feed;
       });
 
-      console.log("Got all feeds: " + JSON.stringify(feeds, null, 2));
+
+
+      //console.log("Got all feeds: " + JSON.stringify(feeds, null, 2));
 
       // Prefetch pages into cache to reduce initial load
       //for (const feed of feeds) {

--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -549,8 +549,29 @@ function getVisualise(itemId) {
   $("#resultPanel").removeClass("active");
   $("#graphPanel").addClass("active");
   $("#tabs")[0].scrollIntoView();
-  $("#graph").html(`<div class="visual"><h2>${storeSuperEvent.itemDataType}</h2><pre>${JSON.stringify(storeSuperEvent.items[itemId], null, 2)}</pre></div>
+
+  // Output both relevant feeds if combined
+  if (
+    storeSuperEvent && Object.values(storeSuperEvent.items).length > 0 &&
+    storeSubEvent && Object.values(storeSubEvent.items).length > 0 &&
+    link
+  ) {
+      const storeSubEventItem = storeSubEvent.items[itemId];
+      const lastSlashIndex = storeSubEventItem.data[link].lastIndexOf('/');
+      const storeSuperEventItemId = storeSubEventItem.data[link].substring(lastSlashIndex + 1);
+      // Note that we intentionally use '==' here and not '===' to cater for those storeSuperEventItem.id
+      // which are purely numeric and stored as a number rather than a string, so we can still match on
+      // storeSuperEventItemId which is always a string:
+      const storeItemForJson = Object.values(storeSuperEvent.items).find(storeSuperEventItem => storeSuperEventItem.id == storeSuperEventItemId);
+
+      $("#graph").html(`<div class="visual"><h2>${storeSuperEvent.itemDataType}</h2><pre>${JSON.stringify(storeItemForJson, null, 2)}</pre></div>
+      <div class="visual"><h2>${storeSubEvent.itemDataType}</h2><pre>${JSON.stringify(storeSubEvent.items[itemId], null, 2)}</pre></div>`);
+
+  }
+  else {
+    $("#graph").html(`<div class="visual"><h2>${storeSuperEvent.itemDataType}</h2><pre>${JSON.stringify(storeSuperEvent.items[itemId], null, 2)}</pre></div>
   <div class="visual"><h2>${storeSubEvent.itemDataType}</h2><pre>${JSON.stringify(storeSubEvent.items[itemId], null, 2)}</pre></div>`);
+  }
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -1,4 +1,3 @@
-let config;
 let endpoint;
 let scheme_1 = null;
 let scheme_2 = null;
@@ -49,7 +48,6 @@ let storeSubEventContentType = null;
 let superEventFeedTypes = ['SessionSeries', 'FacilityUse', 'IndividualFacilityUse'];
 let subEventFeedTypes = ['ScheduledSession', 'Slot', 'Event', 'OnDemandEvent'];
 
-let uniqueUrlStems = [];
 let link = null; // Linking variable between super-event and sub-event feeds
 
 let numListings = 0;
@@ -108,129 +106,33 @@ clearStore(storeItemsForDataQuality);
 
 // -------------------------------------------------------------------------------------------------
 
-// Pulling the display of results out of the API paging loop
-// This is to allow the DQ filters to be applied along with original filters
-
-function postResults(store, filters) {
-
-  //console.log(`DQ Filter Dates: ${filters.DQ_filterDates}`);
-
-  store.numItemsMatchFilters = 0;
-
-  for (const item of Object.values(store.items)) {
-
-    // Add activity to list of unique activities (one of the original filters) 
-    let activities = resolveProperty(item, 'activity');
-    if (Array.isArray(activities)) {
-      activities
-        .map(activity => activity.id || activity['@id'])
-        .filter(activityId => activityId)
-        .forEach(activityId => store.uniqueActivities.add(activityId));
-    }
-
-    // Filters 
-
-    let itemMatchesActivity =
-      !filters.relevantActivitySet
-        ? true
-        : (resolveProperty(item, 'activity') || []).filter(activity =>
-          filters.relevantActivitySet.has(activity.id || activity['@id'] || 'NONE')
-        ).length > 0;
-    let itemMatchesDay =
-      !filters.day
-        ? true
-        : item.data
-        && item.data.eventSchedule
-        && item.data.eventSchedule.filter(x =>
-          x.byDay
-          && x.byDay.includes(filters.day)
-          || x.byDay.includes(filters.day.replace('https', 'http'))
-        ).length > 0;
-    let itemMatchesGender =
-      !filters.gender
-        ? true
-        : resolveProperty(item, 'genderRestriction') === filters.gender;
-    let itemMatchesDQDateFilter =
-      filters.DQ_filterDates === false || (filters.DQ_filterDates === true && !item.DQ_futureDate);
-
-    if (
-      (itemMatchesActivity &&
-        itemMatchesDay &&
-        itemMatchesGender &&
-        itemMatchesDQDateFilter)
-    ) {
-
-      store.numItemsMatchFilters++;
-
-      if (store.ingressOrder === 1) {
-        if (store.numItemsMatchFilters < 100) {
-          results = $("#resultsDiv");
-          results.append(
-            `<div id='col ${store.numItemsMatchFilters}' class='row rowhover'>` +
-            `    <div id='text ${store.numItemsMatchFilters}' class='col-md-1 col-sm-2 text-truncate'>${item.id}</div>` +
-            `    <div class='col'>${(resolveProperty(item, 'name') || '')}</div>` +
-            `    <div class='col'>${(resolveProperty(item, 'activity') || []).filter(activity => activity.id || activity['@id']).map(activity => activity.prefLabel).join(', ')}</div>` +
-            `    <div class='col'>${(getProperty(item, 'startDate') || '')}</div>` +
-            `    <div class='col'>${(getProperty(item, 'endDate') || '')}</div>` +
-            `    <div class='col'>${((item.data && item.data.location && item.data.location.name) || '')}</div>` +
-            `    <div class='col'>` +
-            `        <div class='visualise'>` +
-            `            <div class='row'>` +
-            `                <div class='col' style='text-align: right'>` +
-            // `                    <button id='${store.numItemsMatchFilters}' class='btn btn-secondary btn-sm mb-1 visualiseButton'>Visualise</button>` +
-            `                    <button id='json${store.numItemsMatchFilters}' class='btn btn-secondary btn-sm mb-1'>JSON</button>` +
-            `                    <button id='validate${store.numItemsMatchFilters}' class='btn btn-secondary btn-sm mb-1'>Validate</button>` +
-            //`                    <button id='richness${store.numItemsMatchFilters}' class='btn btn-secondary btn-sm mb-1'>Richness</button>` +
-            `                </div>` +
-            `            </div>` +
-            `        </div>` +
-            `    </div>` +
-            `</div>`
-          );
-
-          $(`#json${store.numItemsMatchFilters}`).on("click", function () {
-            getVisualise(store, item.id);
-          });
-          $(`#validate${store.numItemsMatchFilters}`).on("click", function () {
-            openValidator(store, item.id);
-            //getValidate(item.id);
-          });
-          $(`#richness${store.numItemsMatchFilters}`).on("click", function () {
-            getRichness(store, item.id);
-          });
-
-          if (item.id.length > 8) {
-            $(`#col${store.numItemsMatchFilters}`).hover(
-              function () {
-                $(`#text${store.numItemsMatchFilters}`).removeClass("text-truncate");
-                $(`#text${store.numItemsMatchFilters}`).prop("style", "font-size: 70%");
-              },
-              function () {
-                $(`#text${store.numItemsMatchFilters}`).addClass("text-truncate");
-                $(`#text${store.numItemsMatchFilters}`).prop("style", "font-size: 100%");
-              }
-            );
-          }
-
-        }
-        else if (store.numItemsMatchFilters === 100) {
-          results.append(
-            "<div class='row rowhover'>" +
-            "    <div>Only the first 100 items are shown</div>" +
-            "</div>"
-          );
-        }
-      }
-    }
-
-
+function getFilters() {
+  filters = {
+    activity: $('#activity-list-id').val(),
+    DQ_filterDates: $('#DQ_filterDates').prop("checked"),
+    DQ_filterActivities: $('#DQ_filterActivities').prop("checked"),
+    DQ_filterGeos: $('#DQ_filterGeos').prop("checked"),
+    DQ_filterUrls: $('#DQ_filterUrls').prop("checked"),
+    coverage: $("#Coverage").val(),
+    proximity: $("#Proximity").val(),
+    day: $("#Day").val(),
+    startTime: $("#StartTime").val(),
+    endTime: $("#EndTime").val(),
+    minAge: $("#minAge").val(),
+    maxAge: $("#maxAge").val(),
+    gender: $("#Gender").val(),
+    keywords: $("#Keywords").val(),
+    relevantActivitySet: getRelevantActivitySet($('#activity-list-id').val()),
   }
+  return filters;
 }
 
 // -------------------------------------------------------------------------------------------------
 
 //This replaces the loadRPDE function in Nick's original visualiser adaptation
-function setStoreItems(url, store, filters) {
+//Note the displaying of results happens in dq.js now, to improve filtering
+
+function setStoreItems(url, store) {
 
   store.numPages++;
   if (store.numPages < 50) {
@@ -302,13 +204,13 @@ function setStoreItems(url, store, filters) {
         lastPage = "disabled='disabled'";
       }
 
-      postResults(store, filters);
+      //postResults(store, filters);
 
       const elapsed = luxon.DateTime.now().diff(store.timeHarvestStart, ['seconds']).toObject().seconds.toFixed(2);
       if (url !== page.next) {
         progress.empty();
         progress.text(`${progress_text} Pages loaded: ${store.numPages}; Items: ${store.numItems}; Results: ${store.numItemsMatchFilters} in ${elapsed} seconds...`);
-        setStoreItems(page.next, store, filters);
+        setStoreItems(page.next, store);
       }
       else {
         progress.text(`${progress_text} Pages loaded: ${store.numPages}; Items: ${store.numItems}; Results: ${store.numItemsMatchFilters}; Loading complete in ${elapsed} seconds`);
@@ -347,10 +249,10 @@ function setStoreItems(url, store, filters) {
 
         if (store.ingressOrder === 1 && storeIngressOrder2.firstPage && link) {
           console.log(`Started loading storeIngressOrder2: ${storeIngressOrder2.firstPage}`);
-          setStoreItems(storeIngressOrder2.firstPage, storeIngressOrder2, filters);
+          setStoreItems(storeIngressOrder2.firstPage, storeIngressOrder2);
         }
         else {
-          loadingComplete(filters);
+          loadingComplete();
         }
       }
     })
@@ -463,6 +365,8 @@ function setStoreItemDataType(store) {
 // -------------------------------------------------------------------------------------------------
 
 function loadingStart() {
+  clearCharts();
+  $("#resultPanel").hide();
   if (loadingTimeout) {
     clearTimeout(loadingTimeout);
   }
@@ -501,9 +405,21 @@ function clearCache(store) {
 
 }
 
+
 // -------------------------------------------------------------------------------------------------
 
-function loadingComplete(filters) {
+function clearCharts() {
+  if (chart1) { chart1.destroy(); }
+  if (chart2) { chart2.destroy(); }
+  if (chart3) { chart3.destroy(); }
+  if (chart4) { chart4.destroy(); }
+  if (chart5) { chart5.destroy(); }
+  if (chart6) { chart6.destroy(); }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+function loadingComplete() {
   loadingStarted = null;
   loadingDone = true;
 
@@ -512,20 +428,8 @@ function loadingComplete(filters) {
     loadingTimeout = null;
   }
   $("#loading-time").hide();
-
-
-  if (chart1) {chart1.destroy();}
-  if (chart2) {chart2.destroy();}
-  if (chart3) {chart3.destroy();}
-  if (chart4) {chart4.destroy();}
-  if (chart5) {chart5.destroy();}
-  if (chart6) {chart6.destroy();}
-
-
-
-  runDataQuality(filters);
+  runDataQuality();
   console.log(storeItemsForDataQuality);
-  postResults(storeItemsForDataQuality, filters);
 
 }
 
@@ -637,19 +541,16 @@ function getRelevantActivitySet(id) {
 
 // -------------------------------------------------------------------------------------------------
 
-function getVisualise(store, itemId) {
+function getVisualise(itemId) {
+  console.log(itemId)
   $("#resultTab").removeClass("active");
-  $("#validateTab").removeClass("active");
+  $("#graphTab").removeClass("disabled");
   $("#graphTab").addClass("active");
   $("#resultPanel").removeClass("active");
-  $("#validatePanel").removeClass("active");
   $("#graphPanel").addClass("active");
   $("#tabs")[0].scrollIntoView();
-  $("#graphTab").removeClass("disabled");
-  $("#validateTab").addClass("disabled");
-  $("#validateTab").hide();
-  $("#richnessTab").hide();
-  $("#graph").html(`<pre>${JSON.stringify(store.items[itemId], null, 2)}</pre>`);
+  $("#graph").html(`<div class="visual"><h2>${storeSuperEvent.itemDataType}</h2><pre>${JSON.stringify(storeSuperEvent.items[itemId], null, 2)}</pre></div>
+  <div class="visual"><h2>${storeSubEvent.itemDataType}</h2><pre>${JSON.stringify(storeSubEvent.items[itemId], null, 2)}</pre></div>`);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -660,169 +561,6 @@ function openValidator(store, itemId) {
   const url = `https://validator.openactive.io/#/json/${Base64.encodeURI(jsonString)}`;
   const win = window.open(url, "_blank", "height=800,width=1200");
   win.focus();
-}
-
-// -------------------------------------------------------------------------------------------------
-
-function getValidate(itemId) {
-  $("#resultTab").removeClass("active");
-  $("#resultPanel").removeClass("active");
-
-  $("#graphTab").removeClass("active");
-  $("#graphPanel").removeClass("active");
-
-  $("#validateTab").addClass("active");
-  $("#validatePanel").addClass("active");
-  $("#tabs")[0].scrollIntoView();
-  $("#validateTab").removeClass("disabled");
-
-  $("#richnessTab").hide();
-  $("#validateTab").show();
-
-  let url = $("#endpoint").val() + "/services/" + itemId;
-
-  addApiPanel("Get JSON for validate", false);
-  addApiPanel(url);
-  addApiPanel('<button class="btn btn-secondary" onclick=\'win = window.open("' + url + '", "_blank"); win.focus()\'>Show results</button>', false);
-  updateScroll();
-
-  $.ajax({
-    async: true,
-    type: 'GET',
-    url: url,
-    dataType: "json"
-  })
-    .done(function (data) {
-      postValidate(data);
-    });
-}
-
-// -------------------------------------------------------------------------------------------------
-
-function postValidate(data) {
-  let url = "https://api.porism.com/ServiceDirectoryService/services/validate";
-
-  addApiPanel("Post JSON for validate", false);
-  addApiPanel(url);
-  updateScroll();
-
-  $("#validatePanel").empty();
-  $("#validatePanel").append('<img alt="loading" src="images/ajax-loader.gif">');
-
-  $.post({ url: url, contentType: "application/json" }, JSON.stringify(data), function (resBody) {
-    $("#validatePanel").empty();
-    $("#validatePanel").append('<h5>' + data.name + '</h5><h6>' + data.id + '</h6>');
-    $("#validatePanel").append("<h5>Issues</h5>");
-    for (let i = 0; i < resBody.length; i++) {
-      $("#validatePanel").append("<p>" + resBody[i].message + "</p>");
-    }
-  }, "json");
-}
-
-// -------------------------------------------------------------------------------------------------
-
-function getRichness(store, itemId) {
-  $("#resultTab").removeClass("active");
-  $("#resultPanel").removeClass("active");
-
-  $("#graphTab").removeClass("active");
-  $("#graphPanel").removeClass("active");
-
-  $("#validateTab").removeClass("active");
-  $("#validatePanel").removeClass("active");
-
-  $("#richnessTab").addClass("active");
-  $("#richnessPanel").addClass("active");
-
-  $("#tabs")[0].scrollIntoView();
-  $("#richnessTab").removeClass("disabled");
-
-  $("#validateTab").hide();
-
-  $("#richnessTab").show();
-
-  let url;
-  if (config.schemaType === "OpenReferral") {
-    url = store.firstPage + "/services/complete/" + itemId;
-  } else {
-    url = store.firstPage + "/" + itemId;
-  }
-
-  addApiPanel("Get JSON for richness", false);
-  addApiPanel(url);
-  addApiPanel('<button class="btn btn-secondary" onclick=\'win = window.open("' + url + '", "_blank"); win.focus()\'>Show results</button>', false);
-  updateScroll();
-
-  $.ajax({
-    async: true,
-    type: 'GET',
-    url: url,
-    dataType: "json"
-  })
-    .done(function (data) {
-      postRichness(data);
-    });
-}
-
-// -------------------------------------------------------------------------------------------------
-
-function postRichness(data) {
-  let url = "https://api.porism.com/ServiceDirectoryService/services/richness";
-
-  addApiPanel("Post JSON for richness", false);
-  addApiPanel(url);
-  updateScroll();
-
-  $("#richness").empty();
-  $("#richness").append('<img alt="loading" src="images/ajax-loader.gif">');
-
-  $.post(
-    {
-      url: url,
-      contentType: "application/json"
-    },
-    JSON.stringify(data),
-    "json"
-  )
-    .done(function (resBody) {
-      $("#richness").empty();
-      if (resBody.populated === undefined && resBody.not_populated === undefined) {
-        $("#richness").append("<h3>Error</h3><p>" + resBody[0].message + "</p>");
-        return;
-      }
-      $("#richness").append('<h5>' + (data.name || (data.superEvent && data.superEvent.name)) + '</h5><h6>' + data.id + '</h6>');
-      let Richness = "";
-      let populated = "";
-      for (let i = 0; i < resBody.populated.length; i++) {
-        populated = populated + "<div class='row rowhover'><div class='col-sm-8'>" + resBody.populated[i].name + "</div><div class='col-sm-4'>" + resBody.populated[i].percentage + "%</div></div>";
-      }
-      Richness = Richness + "<div class='card-group mt-2'>";
-      Richness = Richness + (
-        '<div class="card">' +
-        '<div class="card-header bg-light"><h4>Populated</h4></div>' +
-        '<div class="card-body">' + populated + '</div>' +
-        '</div>');
-
-      let not_populated = "";
-      for (let i = 0; i < resBody.not_populated.length; i++) {
-        not_populated = not_populated + "<div class='row rowhover'><div class='col-sm-8'>" + resBody.not_populated[i].name + "</div><div class='col-sm-4'>" + resBody.not_populated[i].percentage + "%</div></div>";
-      }
-      Richness +=
-        '<div class="card">' +
-        '<div class="card-header bg-light"><h4>Not populated</h4></div>' +
-        '<div class="card-body">' + not_populated + '</div>' +
-        '</div></div>';
-
-      $("#richness").append(Richness);
-
-      $("#richness").append("<h3>Overall</h3>" +
-        "<p>Score: " + resBody.richness_percentage + "%</p>");
-    })
-    .fail(function (error) {
-      $("#richness").empty().append("<div>An error has occurred</div>");
-      $("#richness").append('<div>' + error.responseJSON.message + '</div>');
-    });
-
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -954,6 +692,7 @@ function updateEndpointUpdate() {
 function updateDQ_filterDates() {
   DQ_filterDates = $("#DQ_filterDates").prop("checked");
   updateParameters("DQ_filterDates", DQ_filterDates);
+  postDataQuality();
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -961,21 +700,27 @@ function updateDQ_filterDates() {
 function updateDQ_filterActivities() {
   DQ_filterActivities = $("#DQ_filterActivities").prop("checked");
   updateParameters("DQ_filterActivities", DQ_filterActivities);
+  postDataQuality();
 }
+
 
 // -------------------------------------------------------------------------------------------------
 
 function updateDQ_filterGeos() {
   DQ_filterGeos = $("#DQ_filterGeos").prop("checked");
   updateParameters("DQ_filterGeos", DQ_filterGeos);
+  postDataQuality();
 }
+
 
 // -------------------------------------------------------------------------------------------------
 
 function updateDQ_filterUrls() {
   DQ_filterUrls = $("#DQ_filterUrls").prop("checked");
   updateParameters("DQ_filterUrls", DQ_filterUrls);
+  postDataQuality();
 }
+
 
 
 // -------------------------------------------------------------------------------------------------
@@ -1086,24 +831,6 @@ function runForm(pageNumber) {
   $("#resultTab").addClass("active");
   $("#resultPanel").addClass("active");
 
-  filters = {
-    activity: $('#activity-list-id').val(),
-    DQ_filterDates: $('#DQ_filterDates').prop("checked"),
-    DQ_filterActivities: $('#DQ_filterActivities').prop("checked"),
-    DQ_filterGeos: $('#DQ_filterGeos').prop("checked"),
-    DQ_filterUrls: $('#DQ_filterUrls').prop("checked"),
-    coverage: $("#Coverage").val(),
-    proximity: $("#Proximity").val(),
-    day: $("#Day").val(),
-    startTime: $("#StartTime").val(),
-    endTime: $("#EndTime").val(),
-    minAge: $("#minAge").val(),
-    maxAge: $("#maxAge").val(),
-    gender: $("#Gender").val(),
-    keywords: $("#Keywords").val(),
-    relevantActivitySet: getRelevantActivitySet($('#activity-list-id').val()),
-  }
-
   updateScroll();
   $("#results").append("<div><img src='images/ajax-loader.gif' alt='Loading'></div>");
   $("#progress").text(`Loading first page...`);
@@ -1178,7 +905,7 @@ function runForm(pageNumber) {
   }
 
   console.log(`Started loading storeIngressOrder1: ${storeIngressOrder1.firstPage}`);
-  setStoreItems(storeIngressOrder1.firstPage, storeIngressOrder1, filters);
+  setStoreItems(storeIngressOrder1.firstPage, storeIngressOrder1, getFilters());
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -1224,11 +951,13 @@ function setPage() {
   $("#Keywords").on("change", function () {
     updateKeywords();
   });
+
   $("#tabs").hide();
 
   $("#clear").on("click", function () {
     clearForm($("#endpoint").val());
   });
+
   $("#execute").on("click", function () {
     if (!loadingStarted) {
       runForm();
@@ -1240,7 +969,7 @@ function setPage() {
     $.getJSON("/feeds", function (data) {
       $.each(data.feeds, function (index, feed) {
         if (feed.url === $("#endpoint option:selected").val()) {
-          config = feed;
+          // config = feed; //Config was used in OpenReferral - but not now?
         }
       });
     })

--- a/public/dq.js
+++ b/public/dq.js
@@ -925,41 +925,26 @@ function postDataQuality() {
 
   // -------------------------------------------------------------------------------------------------
 
-  let options_percentItemsWithActivity = {
+
+  let filter_chart = {
     chart: {
       height: 300,
       type: 'radialBar',
-      events: {
-        click: function (event, chartContext, config) {
-          //if ([...event.target.classList].includes('#apexcharts-radialbarTrack-0')) {
-          //alert('Chart clicked')
-          console.log(event)
-          console.log(chartContext)
-          console.log(config)
-        }
-      }
     },
-    //title: {
-    //  text: 'Valid Name, Description or Activity ID',
-    //  align: 'center',
-    //  offsetY: 280,
-    //},
-    fill: {
-      colors: ['#A7ABDA'],
+    title: {
+      text: "Filter Active",
+      align: 'center',
+      margin: 0,
+      offsetX: 0,
+      offsetY: 120,
+      style: {
+        fontSize: '30px',
+        fontWeight: 'bold',
+        color: '#2196F3'
+      },
     },
-    //fill: {
-    //  colors: [function({ value, seriesIndex, w }) {
-    //    if(value < 55) {
-    //        return '#7E36AF'
-    //    } else if (value >= 55 && value < 80) {
-    //        return '#164666'
-    //    } else {
-    //        return '#D9534F'
-    //    }
-    //  }]
-    //},
-    series: [rounded3_a, rounded3_b, rounded3_c],
-    labels: ['Activity ID', 'Name', 'Description'],
+    series: [],
+    labels: [''],
     plotOptions: {
       radialBar: {
         hollow: {
@@ -967,158 +952,233 @@ function postDataQuality() {
           size: "65%"
         },
         dataLabels: {
-          show: true,
-          name: {
-            offsetY: 25,
-            show: true,
-            color: "#888",
-            fontSize: "18px"
+          show: false,
+        },
+      }
+    }
+  }
+
+  let options_percentItemsWithActivity = {};
+
+  if (filters.DQ_filterActivities !== true) {
+
+    options_percentItemsWithActivity = {
+      chart: {
+        height: 300,
+        type: 'radialBar',
+        events: {
+          click: function (event, chartContext, config) {
+            //if ([...event.target.classList].includes('#apexcharts-radialbarTrack-0')) {
+            //alert('Chart clicked')
+            console.log(event)
+            console.log(chartContext)
+            console.log(config)
+          }
+        }
+      },
+      fill: {
+        colors: ['#A7ABDA'],
+      },
+      //fill: {
+      //  colors: [function({ value, seriesIndex, w }) {
+      //    if(value < 55) {
+      //        return '#7E36AF'
+      //    } else if (value >= 55 && value < 80) {
+      //        return '#164666'
+      //    } else {
+      //        return '#D9534F'
+      //    }
+      //  }]
+      //},
+      series: [rounded3_a, rounded3_b, rounded3_c],
+      labels: ['Activity ID', 'Name', 'Description'],
+      plotOptions: {
+        radialBar: {
+          hollow: {
+            margin: 15,
+            size: "65%"
           },
-          value: {
-            offsetY: -30,
-            color: "#111",
-            fontSize: "30px",
-            show: true
-          },
-          total: {
+          dataLabels: {
             show: true,
-            label: 'Valid Activity ID',
-            color: "#888",
-            fontSize: "18px",
-            formatter: function (w) {
-              // By default this function returns the average of all series. The below is just an example to show the use of custom formatter function
-              return Math.max(rounded3_a).toFixed(1) + "%";
+            name: {
+              offsetY: 25,
+              show: true,
+              color: "#888",
+              fontSize: "18px"
+            },
+            value: {
+              offsetY: -30,
+              color: "#111",
+              fontSize: "30px",
+              show: true
+            },
+            total: {
+              show: true,
+              label: "Valid Activity ID",
+              color: "#888",
+              fontSize: "18px",
+              formatter: function (w) {
+                // By default this function returns the average of all series. The below is just an example to show the use of custom formatter function
+                return Math.max(rounded3_a).toFixed(1) + "%";
+              }
+            },
+          }
+        }
+      }
+    }
+
+  }
+
+  else {
+    options_percentItemsWithActivity = filter_chart
+  }
+
+  chart2 = new ApexCharts(document.querySelector("#apexchart2"), options_percentItemsWithActivity);
+
+  sleep(500).then(() => { chart2.render(); });
+
+  // -------------------------------------------------------------------------------------------------
+
+  let options_percentItemsWithGeo = {};
+
+  if (filters.DQ_filterGeos !== true) {
+    options_percentItemsWithGeo = {
+      chart: {
+        width: "100%",
+        height: 300,
+        type: 'radialBar',
+      },
+      fill: {
+        colors: ['#B196CB'],
+      },
+      series: [rounded2],
+      labels: [['Valid postcode', 'or coordinates']],
+      plotOptions: {
+        radialBar: {
+          hollow: {
+            margin: 15,
+            size: "65%"
+          },
+          dataLabels: {
+            showOn: "always",
+            name: {
+              offsetY: 25,
+              show: true,
+              color: "#888",
+              fontSize: "18px"
+            },
+            value: {
+              offsetY: -30,
+              color: "#111",
+              fontSize: "30px",
+              show: true
             }
           }
         }
       }
     }
   }
-  chart2 = new ApexCharts(document.querySelector("#apexchart2"), options_percentItemsWithActivity);
-
-  sleep(1000).then(() => {   chart2.render(); });
-
-  // -------------------------------------------------------------------------------------------------
-
-  let options_percentItemsWithGeo = {
-    chart: {
-      width: "100%",
-      height: 300,
-      type: 'radialBar',
-    },
-    fill: {
-      colors: ['#B196CB'],
-    },
-    series: [rounded2],
-    labels: [['Valid postcode', 'or coordinates']],
-    plotOptions: {
-      radialBar: {
-        hollow: {
-          margin: 15,
-          size: "65%"
-        },
-        dataLabels: {
-          showOn: "always",
-          name: {
-            offsetY: 25,
-            show: true,
-            color: "#888",
-            fontSize: "18px"
-          },
-          value: {
-            offsetY: -30,
-            color: "#111",
-            fontSize: "30px",
-            show: true
-          }
-        }
-      }
-    }
+  else {
+    options_percentItemsWithGeo = filter_chart;
   }
 
   chart3 = new ApexCharts(document.querySelector("#apexchart3"), options_percentItemsWithGeo);
-  sleep(2000).then(() => {   chart3.render(); });
+  sleep(1000).then(() => { chart3.render(); });
 
   // -------------------------------------------------------------------------------------------------
 
-  let options_percentItemsNowToFuture = {
-    chart: {
-      width: "100%",
-      height: 300,
-      type: 'radialBar',
-    },
-    fill: {
-      colors: ['#BD82BB'],
-    },
-    series: [rounded1],
-    labels: [['Valid', 'Start Date']],
-    plotOptions: {
-      radialBar: {
-        hollow: {
-          margin: 15,
-          size: "65%"
-        },
-        dataLabels: {
-          showOn: "always",
-          name: {
-            offsetY: 25,
-            show: true,
-            color: "#888",
-            fontSize: "18px"
+  let options_percentItemsNowToFuture = {};
+
+  if (filters.DQ_filterDates !== true) {
+    options_percentItemsNowToFuture = {
+      chart: {
+        width: "100%",
+        height: 300,
+        type: 'radialBar',
+      },
+      fill: {
+        colors: ['#BD82BB'],
+      },
+      series: [rounded1],
+      labels: [['Valid', 'Start Date']],
+      plotOptions: {
+        radialBar: {
+          hollow: {
+            margin: 15,
+            size: "65%"
           },
-          value: {
-            offsetY: -30,
-            color: "#111",
-            fontSize: "30px",
-            show: true
+          dataLabels: {
+            showOn: "always",
+            name: {
+              offsetY: 25,
+              show: true,
+              color: "#888",
+              fontSize: "18px"
+            },
+            value: {
+              offsetY: -30,
+              color: "#111",
+              fontSize: "30px",
+              show: true
+            }
           }
         }
       }
     }
+  }
+  else {
+    options_percentItemsNowToFuture = filter_chart
   }
 
   chart4 = new ApexCharts(document.querySelector("#apexchart4"), options_percentItemsNowToFuture);
-  sleep(3000).then(() => {   chart4.render(); });
+  sleep(1500).then(() => { chart4.render(); });
 
   // -------------------------------------------------------------------------------------------------
+  let options_percentItemsWithUrl = {};
 
-  let options_percentItemsWithUrl = {
-    chart: {
-      width: "100%",
-      height: 300,
-      type: 'radialBar',
-    },
-    fill: {
-      colors: ['#C76DAC'],
-    },
-    series: [rounded4],
-    labels: [['Unique', 'URLs']],
-    plotOptions: {
-      radialBar: {
-        hollow: {
-          margin: 15,
-          size: "65%"
-        },
-        dataLabels: {
-          showOn: "always",
-          name: {
-            offsetY: 25,
-            show: true,
-            color: "#888",
-            fontSize: "18px"
+  if (filters.DQ_filterUrls !== true) {
+    options_percentItemsWithUrl = {
+      chart: {
+        width: "100%",
+        height: 300,
+        type: 'radialBar',
+      },
+      fill: {
+        colors: ['#C76DAC'],
+      },
+      series: [rounded4],
+      labels: [['Unique', 'URLs']],
+      plotOptions: {
+        radialBar: {
+          hollow: {
+            margin: 15,
+            size: "65%"
           },
-          value: {
-            offsetY: -30,
-            color: "#111",
-            fontSize: "30px",
-            show: true
+          dataLabels: {
+            showOn: "always",
+            name: {
+              offsetY: 25,
+              show: true,
+              color: "#888",
+              fontSize: "18px"
+            },
+            value: {
+              offsetY: -30,
+              color: "#111",
+              fontSize: "30px",
+              show: true
+            }
           }
         }
       }
     }
   }
+  else {
+    options_percentItemsWithUrl = filter_chart;
+  }
+
   chart5 = new ApexCharts(document.querySelector("#apexchart5"), options_percentItemsWithUrl);
-  sleep(4000).then(() => {   chart5.render(); });
+  sleep(2000).then(() => { chart5.render(); });
 
 
   // -------------------------------------------------------------------------------------------------
@@ -1267,9 +1327,9 @@ function postDataQuality() {
   }
 
   chart6 = new ApexCharts(document.querySelector("#apexchart6"), spark6);
-  sleep(5000).then(() => {   chart6.render(); });
+  sleep(2500).then(() => { chart6.render(); });
 
 
-  sleep(6000).then(() => {    $("#resultPanel").fadeIn("slow");  });
+  sleep(3000).then(() => { $("#resultPanel").fadeIn("slow"); });
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -223,7 +223,7 @@
                             <div id="apexchart2"></div>
                         </div>
                         <div class="explainer">
-                            <p>As well as activity ID and name, adding a decription can engage participants and help
+                            <p>As well as activity ID and name, adding a description can engage participants and help
                                 them decide if the activity is right for them.</p>
                         </div>
                     </div>
@@ -311,12 +311,6 @@
                         Results </a></li>
                 <li class="nav-item"><a id="graphTab" class="nav-link disabled" href="#graphPanel" data-toggle="tab">
                         View Raw JSON Data</a></li>
-                <li class="nav-item"><a id="validateTab" class="nav-link disabled" href="#validatePanel"
-                        data-toggle="tab">
-                        Validate</a></li>
-                <li class="nav-item"><a id="richnessTab" class="nav-link disabled" href="#richnessPanel"
-                        data-toggle="tab">
-                        Richness</a></li>
             </ul>
 
             <div class="tab-content">
@@ -326,32 +320,7 @@
                     </div>
                 </div>
                 <div class="tab-pane" id="graphPanel">
-                    <div id="graphLoading"></div>
-                    <div class="container-fluid">
-                        <div class="flex_row" style="display: none;">
-                            <div class="col-sm2-2">
-                                <label class="mr-1" for="format">Format</label>
-                                <select id="format" class="form-control mr-1 mb-2" style="width:auto">
-                                    <option value="json">Json</option>
-                                    <option value="image">GUI</option>
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="flex_row">
                         <div id="graph" class="graph">
-
-                        </div>
-                    </div>
-                </div>
-                <div class="tab-pane" id="validatePanel">
-                    <div id="validate" class="col-sm-12" style="padding-left: 3%">
-
-                    </div>
-                </div>
-                <div class="tab-pane" id="richnessPanel">
-                    <div id="richness" class="col-sm-12 col-md-10 col-lg-8 mt-2" style="padding-left: 1%">
-
                     </div>
                 </div>
             </div>

--- a/public/style.css
+++ b/public/style.css
@@ -76,6 +76,7 @@ div.col-md-2, div.col-md-6 {
   width: 100%;
   color: #fff;
   padding: 5px;
+  border-radius: 8px 8px 0px 0px; 
 }
 
 #summaryPanel {

--- a/public/style.css
+++ b/public/style.css
@@ -41,9 +41,13 @@ div.col-md-2, div.col-md-6 {
 }
 
 .graph {
+  display: flex;
+  flex-wrap: wrap;
   text-align: left;
-  width: 85vh;
-  height: 85vw;
+}
+
+.visual {
+  width: 50%;
 }
 
 .noPadding {


### PR DESCRIPTION
Moved 'post results' code outside of paging loop.
DQ pass/fail calculated on whole datastore, once.
Filters trigger recounting of matching records and updates charts and results.
Raw JSON shown for parent and child feeds.