### PR TITLE
Allowed for superEvent IDs that include a forward-slash

### DIFF
--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -874,12 +874,8 @@ function setJSONTab(itemId, switchTab) {
     storeSubEvent.feedType !== null
   ) {
     const storeSubEventItem = storeSubEvent.items[itemId];
-    const lastSlashIndex = storeSubEventItem.data[link].lastIndexOf('/');
-    const storeSuperEventItemId = storeSubEventItem.data[link].substring(lastSlashIndex + 1);
-    // Note that we intentionally use '==' here and not '===' to cater for those storeSuperEventItem.id
-    // which are purely numeric and stored as a number rather than a string, so we can still match on
-    // storeSuperEventItemId which is always a string:
-    const storeSuperEventItem = Object.values(storeSuperEvent.items).find(storeSuperEventItem => storeSuperEventItem.id == storeSuperEventItemId);
+    const storeSuperEventItemId = String(storeSubEventItem.data[link]).split('/').at(-1);
+    const storeSuperEventItem = Object.values(storeSuperEvent.items).find(storeSuperEventItem => String(storeSuperEventItem.id).split('/').at(-1) === storeSuperEventItemId);
 
     if (storeSuperEventItem) {
       document.getElementById('json-tab-1').innerHTML = `

--- a/public/dq.js
+++ b/public/dq.js
@@ -173,12 +173,8 @@ function setStoreDataQualityItems() {
 
     for (const [storeSubEventItemIdx, storeSubEventItem] of Object.values(storeSubEvent.items).entries()) {
       if (storeSubEventItem.data && storeSubEventItem.data[link] && typeof storeSubEventItem.data[link] === 'string') {
-        const lastSlashIndex = storeSubEventItem.data[link].lastIndexOf('/');
-        const storeSuperEventItemId = storeSubEventItem.data[link].substring(lastSlashIndex + 1);
-        // Note that we intentionally use '==' here and not '===' to cater for those storeSuperEventItem.id
-        // which are purely numeric and stored as a number rather than a string, so we can still match on
-        // storeSuperEventItemId which is always a string:
-        const storeSuperEventItem = Object.values(storeSuperEvent.items).find(storeSuperEventItem => storeSuperEventItem.id == storeSuperEventItemId);
+        const storeSuperEventItemId = String(storeSubEventItem.data[link]).split('/').at(-1);
+        const storeSuperEventItem = Object.values(storeSuperEvent.items).find(storeSuperEventItem => String(storeSuperEventItem.id).split('/').at(-1) === storeSuperEventItemId);
         // If the match isn't found then the super-event has been deleted, so lose the sub-event info:
         if (storeSuperEventItem && storeSuperEventItem.data) {
           // Note that JSON.parse(JSON.stringify()) does not work for sets. Not an issue here as the items

--- a/public/index.html
+++ b/public/index.html
@@ -397,7 +397,7 @@
     <script src="https://cdn.jsdelivr.net/npm/js-base64@3.6.0/base64.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@openactive/skos@1.4.3/dist/skos.min.js"></script>
     <script src="https://neofusion.github.io/hierarchy-select/v2/dist/hierarchy-select.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+    <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script> <!-- Add e.g. '@3.35.0' to the end of the URL to use a specific version number -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="apisearch.js"></script>


### PR DESCRIPTION
- Allowed for superEvent IDs that include a forward-slash, expecting the unique part to be after the slash