### PR TITLE
Sorted caching. Ensured server-side and not client-side.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -386,6 +386,7 @@
 
 
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
         crossorigin="anonymous"></script>


### PR DESCRIPTION
- Added axios to the client-side code, and used to replace use of 'ajax' and 'fetch' use throughout. This was triggered by observations of client-side caching behaviour via ajax, which is still suffered by default with axios but which can be disabled more easily.
- Sorted server-side cache handling, ensuring that the right URLs go in when run for the first time, and that the right URLs go out when cleared. This can be observed at the '/api/cache/index' endpoint.
- Cleared server-side cache for the penultimate RPDE page as well as final RPDE page, as the former may not be full on the first read of a feed and so could be adjusted before the next read. Previously we only cleared the last page, which on its own isn't enough (or rather we tried to clear, as server-side caching wasn't actually working due to client-side caching from default ajax).
- Ensured that all HTTP requests from our server to the web have a timeout
- Ensured that all HTTP requests from the client to our server have a timeout which is greater than that from our server to the web, such that the former encapsulates the latter
- Modified the cache-clearing endpoint to have the same naming format as other apicache utility endpoints
- Modified the harvest() function for pre-fetching to use a relative URL path, as the previous version may have had an issue when deployed to Heroku
- Modified some string formatting
- Commented some apparently dead code