### PR TITLE
Allowed all feed types to pass app.js

### DIFF
--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -57,7 +57,7 @@ let storeSuperEvent;
 let storeSubEvent;
 
 let superEventContentTypes = ['SessionSeries', 'FacilityUse', 'IndividualFacilityUse'];
-let subEventContentTypes = ['ScheduledSession', 'Slot', 'Event', 'OnDemandEvent'];
+let subEventContentTypes = ['ScheduledSession', 'ScheduledSessions', 'sessions', 'Slot', 'Slot for FacilityUse', 'Event', 'OnDemandEvent'];
 
 let sessionSeriesUrlParts = [
   'session-series',


### PR DESCRIPTION
- Added some content types in apisearch.js that were previously filtered or normalised out in app.js
- Added some further server-side error messages
- Ensured that all feeds from initial feed grab are present regardless of feed type, even if undefined
- Ensured that missing properties from initial feed grab are still present as empty strings
- Sorted indentation in app.js