### PR TITLE
Added more options for edge cases, greater flexibility throughout

### DIFF
--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -58,10 +58,10 @@ let storeSubEvent;
 
 const superEventContentTypesSeries = ['SessionSeries'];
 const superEventContentTypesFacility = ['FacilityUse', 'IndividualFacilityUse'];
-const superEventContentTypesEvent = ['EventSeries'];
+const superEventContentTypesEvent = ['EventSeries', 'HeadlineEvent'];
 const superEventContentTypesCourse = ['CourseInstance'];
 const superEventContentTypes = Array.prototype.concat(superEventContentTypesSeries, superEventContentTypesFacility, superEventContentTypesEvent, superEventContentTypesCourse);
-const subEventContentTypesSession = ['ScheduledSession', 'ScheduledSessions', 'sessions'];
+const subEventContentTypesSession = ['ScheduledSession', 'ScheduledSessions', 'session', 'sessions'];
 const subEventContentTypesSlot = ['Slot', 'Slot for FacilityUse'];
 const subEventContentTypesEvent = ['Event', 'OnDemandEvent'];
 const subEventContentTypes = Array.prototype.concat(subEventContentTypesSession, subEventContentTypesSlot, subEventContentTypesEvent);
@@ -425,10 +425,10 @@ function setStoreItems(url, store) {
             store.itemKind !== store.itemDataType
           ) {
             console.warn(
-              `Mismatched content types:\n` +
-              `  feedType: ${store.feedType}\n` +
-              `  itemKind: ${store.itemKind}\n` +
-              `  itemDataType: ${store.itemDataType}`
+              `storeIngressOrder${store.ingressOrder} mismatched content types:\n` +
+              `\tfeedType: ${store.feedType}\n` +
+              `\titemKind: ${store.itemKind}\n` +
+              `\titemDataType: ${store.itemDataType}`
             );
           }
 
@@ -630,6 +630,7 @@ function setStoreItemKind(store) {
       break;
     default:
       store.itemKind = 'mixed';
+      console.warn(`storeIngressOrder${store.ingressOrder} mixed item kinds: [${uniqueItemKinds}]`);
       break;
   }
 }
@@ -660,6 +661,7 @@ function setStoreItemDataType(store) {
       break;
     default:
       store.itemDataType = 'mixed';
+      console.warn(`storeIngressOrder${store.ingressOrder} mixed item data types: [${uniqueItemDataTypes}]`);
       break;
   }
 }


### PR DESCRIPTION
- Added more options to superEventContentTypesEvent
- Added more options to subEventContentTypesSession
- Added more options for having a 'link' of 'superEvent'
- Added more options to determination of subEventId
- Added itemKind to list of options for deciding content type. This is typically less reliable than feedType and itemDataType, so it is a last resort.
- Modified determination of spark1SeriesName to be more exact in certain cases
- Modified logging to actually show all itemKind and itemDataType options if mixed