### PR TITLE
Fixed tab change on load

### DIFF
--- a/public/apisearch.js
+++ b/public/apisearch.js
@@ -291,6 +291,7 @@ function clearDisplay() {
   $('#loading-time').hide();
   $('#record-limit').hide();
   $('#filterRows').hide();
+  $('#output').hide();
   $('#tabs').hide();
   clearCharts();
   clearTabs();

--- a/public/dq.js
+++ b/public/dq.js
@@ -686,7 +686,7 @@ function postDataQuality() {
   disableFilters();
   clearCharts();
 
-  $("#resultPanel").hide();
+  $("#tabs").hide();
 
   $("#resultTab").addClass("active");
   $("#resultPanel").addClass("active");
@@ -1219,7 +1219,7 @@ function postDataQuality() {
   // -------------------------------------------------------------------------------------------------
 
   $('#clear').prop('disabled', true);
-  $('#tabs').fadeIn('slow');
+  $('#output').fadeIn('slow');
 
   // -------------------------------------------------------------------------------------------------
 
@@ -1837,7 +1837,7 @@ function postDataQuality() {
 
   // -------------------------------------------------------------------------------------------------
 
-  sleep(1400).then(() => { $('#resultPanel').fadeIn('slow'); });
+  sleep(1400).then(() => { $('#tabs').fadeIn('slow'); });
   sleep(1600).then(() => {
     if (storeDataQuality.numFilteredItems !== 0) {
       $('#filterRows').fadeIn('slow');

--- a/public/index.html
+++ b/public/index.html
@@ -17,23 +17,26 @@
     <title>OpenActive Data Explorer</title>
 </head>
 
-<body>
+<body style="overflow: scroll">
     <!-- Header image and text -->
-    <div class="flex_row mainheading" style="padding-left: 2%; padding-right: 2%; padding-top: 10px">
-        <div class="col-md-6 col-sm-8" style="padding-left: 1%; padding-right: 1%;">
-            <img src="images/OpenActive-Landscape-Logo-2.png" style="max-width: 100%; max-height: 100%;"></img>
-        </div>
-        <div class="col-md-6 col-sm-8" style="padding-left: 1%; padding-right: 1%;">
-            <h3 style="text-align:left;">Data Visualiser / Data Quality Explorer 
-                <span id='beta'>BETA</span>
-            </h3>
+    <div class="container-fluid mainheading">
+        <div class="flex_row">
+            <div class="col-md-6 col-sm-8">
+                <div class="flex_row top">
+                    <img src="images/OpenActive-Landscape-Logo-2.png" style="max-width: 100%;"></img>
+                </div>
+            </div>
+            <div class="col-md-6 col-sm-8">
+                <div class="flex_row top">
+                    <h3 style="text-align:left;">Data Visualiser / Data Quality Explorer</h3>
+                    <h3><span id='beta'>BETA</span></h3>
+                </div>
+            </div>
         </div>
     </div>
 
-
-
     <!-- Controls and logs -->
-    <div class="container-fluid" style="padding-left: 2%; padding-right: 2%; height: 300px; overflow-y: visible;">
+    <div class="container-fluid controls">
         <div class="flex_row">
 
             <!-- Left column: Controls -->
@@ -81,23 +84,33 @@
                     </div>
                 </div>
 
-                <div class="flex_row top" id="filterRows" style="display:none;">
-                    <div class="col-md-4" style="max-width:33%;">
-                        <label class="ml-1">Filter by Organiser:</label>
-                        <!-- Could try: disabled="disabled" -->
-                        <div id="organizer-list-dropdown">
+                <div id="filterRows" style="display:none;">
+                    <div class="flex_row top">
+                        <div class="col-md-4" style="max-width:33%;">
+                            <label class="ml-1">Filter by Organiser:</label>
+                            <!-- Could try: disabled="disabled" -->
+                        </div>
+                        <div class="col-md-4" style="max-width:33%;">
+                            <label class="ml-1">Filter by Activity:</label>
+                            <!-- Could try: disabled="disabled" -->
+                        </div>
+                        <div class="col-md-4" style="max-width:33%;">
+                            <label class="ml-1">Filter by Location:</label>
+                            <!-- Could try: disabled="disabled" -->
                         </div>
                     </div>
-                    <div class="col-md-4" style="max-width:33%;">
-                        <label class="ml-1">Filter by Activity:</label>
-                        <!-- Could try: disabled="disabled" -->
-                        <div id="activity-list-dropdown">
+                    <div class="flex_row">
+                        <div class="col-md-4" style="max-width:33%;">
+                            <div id="organizer-list-dropdown">
+                            </div>
                         </div>
-                    </div>
-                    <div class="col-md-4" style="max-width:33%;">
-                        <label class="ml-1">Filter by Location:</label>
-                        <!-- Could try: disabled="disabled" -->
-                        <div id="location-list-dropdown">
+                        <div class="col-md-4" style="max-width:33%;">
+                            <div id="activity-list-dropdown">
+                            </div>
+                        </div>
+                        <div class="col-md-4" style="max-width:33%;">
+                            <div id="location-list-dropdown">
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -212,7 +225,7 @@
                 <div id="record-limit" style="display: none;">
                     <h5>Note: only the first 25,000 items (approx.) from the API are being processed.</h5>
                 </div>
-                <div id="progress">
+                <div id="progress" class="flex_row top">
                 </div>
             </div>
 
@@ -220,124 +233,125 @@
     </div>
 
     <!-- Data quality metrics -->
-    <div id='tabs' style="padding-left: 2%; padding-right: 2%; display: none; ">
+    <div id="output" class="container-fluid output">
 
-        <div class="tab-content">
-            <div class="tab-pane active" id="summaryPanel">
-                <div class="flex_row">
-                    <div id="grad" class="col-md-12>">
-                        <h2>DISCOVERY</h2>
-                        <h4>Data Quality Metrics linked to Use Cases</h4>
-                        <h2>BOOKING</h2>
-                    </div>
+        <div id="summaryPanel">
+
+            <div class="flex_row">
+                <div id="grad" class="col-md-12>">
+                    <h2>DISCOVERY</h2>
+                    <h4>Data Quality Metrics linked to Use Cases</h4>
+                    <h2>BOOKING</h2>
                 </div>
-
-                <div class="flex_row sparkboxes">
-                    <div class="col-md-2">
-                        <div class="box box1">
-                            <div id="apexchart1"></div>
-                        </div>
-                        <div class="explainer">
-                            <p>Using the official activity list helps developers create better user experiences,
-                                for
-                                example, by grouping activities to simplify search.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class="box box2">
-                            <div id="apexchart2"></div>
-                        </div>
-                        <div class="explainer">
-                            <p>As well as activity ID and name, adding a description can engage participants and
-                                help
-                                them decide if the activity is right for them.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class="box box3">
-                            <div id="apexchart3"></div>
-                        </div>
-                        <div class="explainer">
-                            <p>Developers use postcodes or coordinates to display activities on a map and to
-                                search by
-                                location.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class="box box4">
-                            <div id="apexchart4"></div>
-                        </div>
-                        <div class="explainer">
-                            <p>Activity finders focus on upcoming events.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class="box box5">
-                            <div id="apexchart5a"></div>
-                            <div id="apexchart5b"></div>
-                        </div>
-                        <div class="explainer">
-                            <p>Having a URL link directly to the booking page for a specific series or session
-                                significantly
-                                improves user experience.</p>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class="box box6">
-                            <div id="apexchart6"></div>
-                        </div>
-                        <div class="explainer">
-                            <p>This charts shows the start dates of scheduled sessions or slots where available.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="flex_row">
-                    <div class="col-md-2">
-                    </div>
-                    <div class="col-md-2">
-                        <div class='filter'>
-                            <!-- Rounded switch -->
-                            <label class="switch">
-                                <input type="checkbox" id="DQ_filterActivities">
-                                <span class="slider round"></span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class='filter'>
-                            <!-- Rounded switch -->
-                            <label class="switch">
-                                <input type="checkbox" id="DQ_filterGeos">
-                                <span class="slider round"></span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class='filter'>
-                            <!-- Rounded switch -->
-                            <label class="switch">
-                                <input type="checkbox" id="DQ_filterDates">
-                                <span class="slider round"></span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                        <div class='filter'>
-                            <!-- Rounded switch -->
-                            <label class="switch">
-                                <input type="checkbox" id="DQ_filterUrls">
-                                <span class="slider round"></span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="col-md-2">
-                    </div>
-                </div>
-
             </div>
 
+            <div class="flex_row sparkboxes">
+                <div class="col-md-2">
+                    <div class="box box1">
+                        <div id="apexchart1"></div>
+                    </div>
+                    <div class="explainer">
+                        <p>Using the official activity list helps developers create better user experiences,
+                            for
+                            example, by grouping activities to simplify search.</p>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="box box2">
+                        <div id="apexchart2"></div>
+                    </div>
+                    <div class="explainer">
+                        <p>As well as activity ID and name, adding a description can engage participants and
+                            help
+                            them decide if the activity is right for them.</p>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="box box3">
+                        <div id="apexchart3"></div>
+                    </div>
+                    <div class="explainer">
+                        <p>Developers use postcodes or coordinates to display activities on a map and to
+                            search by
+                            location.</p>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="box box4">
+                        <div id="apexchart4"></div>
+                    </div>
+                    <div class="explainer">
+                        <p>Activity finders focus on upcoming events.</p>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="box box5">
+                        <div id="apexchart5a"></div>
+                        <div id="apexchart5b"></div>
+                    </div>
+                    <div class="explainer">
+                        <p>Having a URL link directly to the booking page for a specific series or session
+                            significantly
+                            improves user experience.</p>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="box box6">
+                        <div id="apexchart6"></div>
+                    </div>
+                    <div class="explainer">
+                        <p>This charts shows the start dates of scheduled sessions or slots where available.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex_row">
+                <div class="col-md-2">
+                </div>
+                <div class="col-md-2">
+                    <div class='filter'>
+                        <!-- Rounded switch -->
+                        <label class="switch">
+                            <input type="checkbox" id="DQ_filterActivities">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class='filter'>
+                        <!-- Rounded switch -->
+                        <label class="switch">
+                            <input type="checkbox" id="DQ_filterGeos">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class='filter'>
+                        <!-- Rounded switch -->
+                        <label class="switch">
+                            <input type="checkbox" id="DQ_filterDates">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class='filter'>
+                        <!-- Rounded switch -->
+                        <label class="switch">
+                            <input type="checkbox" id="DQ_filterUrls">
+                            <span class="slider round"></span>
+                        </label>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                </div>
+            </div>
+
+        </div> <!-- Close id=summaryPanel -->
+
+        <div id="tabs">
             <ul class="nav nav-tabs">
                 <li class="nav-item"><a id="resultTab" class="nav-link active" href="#resultPanel" data-toggle="tab">
                         Results</a></li>
@@ -352,7 +366,6 @@
                 <li class="nav-item"><a id="mapTab" class="nav-link" href="#mapPanel" data-toggle="tab">
                         Map</a></li>
             </ul>
-
             <div class="tab-content" style="min-height: 100vh;">
                 <div class="tab-pane active" id="resultPanel">
                     <div id="results" class="col-sm-12">
@@ -379,13 +392,12 @@
                     </div>
                 </div>
             </div>
+        </div> <!-- Close id=tabs -->
 
-            <div id="footer" style="min-height:2%;"> &nbsp;
-            </div>
-        </div>
+    </div> <!-- Close id=output -->
+
+    <div id="footer" style="min-height:2%;"> &nbsp;
     </div>
-
-
 
     <script src="https://code.jquery.com/jquery-3.4.1.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -4,9 +4,26 @@
 }
 
 .mainheading {
-  margin: 5px;
+  padding-left: 2%;
+  padding-right: 2%;
+  padding-top: 10px;
   justify-content: space-evenly;
   align-items: center;
+}
+
+.controls {
+  padding-left: 2%;
+  padding-right: 2%;
+  padding-top: 10px;
+  min-height: 300px;
+  overflow-y: visible;
+}
+
+.output {
+  padding-left: 2%;
+  padding-right: 2%;
+  padding-top: 20px;
+  display: none;
 }
 
 #beta {
@@ -20,10 +37,10 @@
   margin-left: 10px;
 }
 
-#progress {
+/* #progress {
   margin-right: 10px;
   margin-left: 10px;
-}
+} */
 
 div.col-md-2, div.col-md-6 {
   margin-right: 0px;


### PR DESCRIPTION
- Modified HTML layout and sub-division, initially to fix an issue with tab panel fade-in that allowed the user to adjust tab during load, as display then snapped back to the first tab regardless of what tab was selected. Further adjustments on top of that for general consistency.
- Modified HTML to always include space for a scroll bar, which stops width adjustment as page content gets longer as it's generated